### PR TITLE
feat: implement claims-based secure identity extraction and make serv…

### DIFF
--- a/src/AIFinancialService/AIFinancialService.csproj
+++ b/src/AIFinancialService/AIFinancialService.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="DotNetEnv" Version="3.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.16" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2">

--- a/src/AIFinancialService/Controllers/AgentController.cs
+++ b/src/AIFinancialService/Controllers/AgentController.cs
@@ -3,12 +3,15 @@ using Microsoft.AspNetCore.Mvc;
 using AIFinancialService.Models;
 using UglyToad.PdfPig;
 using System.Text;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 
 namespace AIFinancialService.Controllers
 {
 	[ApiController]
 	[Route("api/[controller]")]
+	[Authorize]
 	public class AgentController : ControllerBase
 	{
 		private readonly IChatHistoryService _chatHistoryService;
@@ -40,14 +43,10 @@ namespace AIFinancialService.Controllers
 				throw new BadHttpRequestException("Message cannot be empty");
 			}
 
-			if (!Guid.TryParse(request.UserId, out Guid userGuid)) 
-			{
-				throw new BadHttpRequestException("Invalid User ID format. Please provide a valid GUID.");
-			}
 			// Get gemini response
 			try
 			{
-				return _financeAgentService.StreamFinanceAssistResponse(request.SessionId ,request.UserMessage, userGuid);
+				return _financeAgentService.StreamFinanceAssistResponse(request.SessionId ,request.UserMessage);
 			}
 			catch (Exception) 
 			{

--- a/src/AIFinancialService/Models/ChatRequest.cs
+++ b/src/AIFinancialService/Models/ChatRequest.cs
@@ -9,7 +9,5 @@ namespace AIFinancialService.Models
 		[JsonPropertyName("UserMessage")]
 		public string UserMessage { get; set; } = string.Empty;
 
-		[JsonPropertyName("UserId")]
-		public string? UserId { get; set; }
 	}
 }

--- a/src/AIFinancialService/Program.cs
+++ b/src/AIFinancialService/Program.cs
@@ -1,6 +1,5 @@
 using AIFinancialService.Plugins;
 using AIFinancialService.Services;
-using DotNetEnv;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -56,6 +55,7 @@ try
 
 
 	builder.Services.AddTransient<IUserInfo, SqlUserData>();
+	builder.Services.AddHttpContextAccessor();
 
 
 	kernelBuiler.Plugins.AddFromType<BankingInfo>();
@@ -107,11 +107,44 @@ try
 		options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
 	});
 
+	var jwtSecretKey = System.Environment.GetEnvironmentVariable("JWT_KEY") ?? builder.Configuration["Jwt:Secret"];
+	var jwtIssuer = System.Environment.GetEnvironmentVariable("JWT_ISSUER") ?? builder.Configuration["Jwt:Issuer"];
+	var jwtAudience = System.Environment.GetEnvironmentVariable("JWT_AUDIENCE") ?? builder.Configuration["Jwt:Audience"];
+
+	builder.Services.AddAuthentication(options =>
+	{
+		options.DefaultAuthenticateScheme = Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme;
+		options.DefaultChallengeScheme = Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme;
+	})
+	.AddJwtBearer(options =>
+	{
+		options.RequireHttpsMetadata = false;
+		options.SaveToken = true;
+		options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
+		{
+			ValidateIssuer = true,
+			ValidIssuer = jwtIssuer,
+
+			ValidateAudience = true,
+			ValidAudience = jwtAudience,
+
+			ValidateLifetime = true,
+			ClockSkew = TimeSpan.FromMinutes(5),
+
+			ValidateIssuerSigningKey = true,
+			IssuerSigningKey = new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(jwtSecretKey ?? "FallbackSecretKeyForLocalCompilationOnly"))
+		};
+	});
+
 
 	// 4. BUILD & RUN
 	var app = builder.Build();
 
 	Console.WriteLine("App Build Successful. Mapping routes...");
+
+	app.UseRouting(); 
+	app.UseAuthentication(); 
+	app.UseAuthorization();
 	app.MapControllers();
 
 	Console.WriteLine("Everything ready. Running app...");

--- a/src/AIFinancialService/Services/FinanceAgentService.cs
+++ b/src/AIFinancialService/Services/FinanceAgentService.cs
@@ -9,20 +9,23 @@ namespace AIFinancialService.Services
 	public class FinanceAgentService : IFinanceAgentService
 	{
 		private readonly Kernel _kernel;
+		private readonly IHttpContextAccessor _httpContextAccessor;
 		private readonly IChatCompletionService _chatService;
 		private readonly IChatHistoryService _historyService;
 
 
-		public FinanceAgentService(Kernel kernel, IChatCompletionService chatCompletion, IChatHistoryService historyService) 
+		public FinanceAgentService(Kernel kernel, IHttpContextAccessor httpContextAccessor, IChatCompletionService chatCompletion, IChatHistoryService historyService) 
 		{
 			_kernel = kernel;
+			_httpContextAccessor = httpContextAccessor;
 			_chatService = kernel.GetRequiredService<IChatCompletionService>();
 			_historyService = historyService;
 
 		}
 
-		public async Task<string> GetAiResponseAsync(Guid sessionId, string userMessage, Guid userId) 
+		public async Task<string> GetAiResponseAsync(Guid sessionId, string userMessage) 
 		{
+			var userId = GetUserIdFromClaims();
 			await _historyService.EnsureSessionExistsAsync(sessionId);
 
 			await _historyService.SaveMessageAsync(new ChatMessageRecord
@@ -76,8 +79,9 @@ namespace AIFinancialService.Services
 			Console.WriteLine($"Session {sessionId} has been reset in the database.");
 		}
 
-		public async IAsyncEnumerable<string> StreamFinanceAssistResponse(Guid sessionId, string prompt, Guid userId)
+		public async IAsyncEnumerable<string> StreamFinanceAssistResponse(Guid sessionId, string prompt)
 		{
+			var userId = GetUserIdFromClaims();
 			await _historyService.EnsureSessionExistsAsync(sessionId);
 
 			var fullResponse = new StringBuilder();
@@ -89,8 +93,10 @@ namespace AIFinancialService.Services
 				ToolCallBehavior = GeminiToolCallBehavior.AutoInvokeKernelFunctions
 			};
 
+			_kernel.Data["userId"] = userId.ToString();
+
 			// This makes it available to any Plugin  that gets called
-			var args = GetExecutionArguments(userId);
+			//var args = GetExecutionArguments(userId);
 
 
 			await foreach (var chunk in _chatService.GetStreamingChatMessageContentsAsync(history, settings, _kernel))
@@ -155,5 +161,15 @@ namespace AIFinancialService.Services
 			return history;
 		}
 
+		private Guid GetUserIdFromClaims()
+		{
+			var claim = _httpContextAccessor.HttpContext?.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
+			if (claim == null) throw new UnauthorizedAccessException("User context is missing in JWT.");
+			return Guid.Parse(claim.Value);
+
+		}
+
+
 	}
+
 }

--- a/src/AIFinancialService/Services/IFinanceAgentService.cs
+++ b/src/AIFinancialService/Services/IFinanceAgentService.cs
@@ -3,12 +3,12 @@
 	public interface IFinanceAgentService
 	{
 		
-		Task<string> GetAiResponseAsync(Guid sessionId, string userMessage, Guid userId);
+		Task<string> GetAiResponseAsync(Guid sessionId, string userMessage);
 
 		// To reset conversation
 		Task ResetChatAsync(Guid sessionId);
 
-		IAsyncEnumerable<string> StreamFinanceAssistResponse(Guid sessionId ,string prompt, Guid userId);
+		IAsyncEnumerable<string> StreamFinanceAssistResponse(Guid sessionId ,string prompt);
 
 	}
 }

--- a/src/Payment.ClientView/Services/TokenService.cs
+++ b/src/Payment.ClientView/Services/TokenService.cs
@@ -10,9 +10,11 @@ namespace Payment.ClientView.Services
 	public class TokenService : ITokenService
 	{
 		private readonly SymmetricSecurityKey _key;
+		private readonly IConfiguration _config;
 
 		public TokenService(IConfiguration config) 
 		{
+			_config = config;
 			var secret = Environment.GetEnvironmentVariable("JWT_KEY") ?? config["Jwt:Key"];
 			if (string.IsNullOrEmpty(secret) || secret.Length < 32) 
 			{
@@ -31,11 +33,16 @@ namespace Payment.ClientView.Services
 
 			var creds = new SigningCredentials(_key, SecurityAlgorithms.HmacSha256Signature);
 
+			var issuer = Environment.GetEnvironmentVariable("JWT_ISSUER") ?? _config["Jwt:Issuer"];
+			var audience = Environment.GetEnvironmentVariable("JWT_AUDIENCE") ?? _config["Jwt:Audience"];
+
 			var tokenDescriptor = new SecurityTokenDescriptor
 			{
 				Subject = new ClaimsIdentity(claims),
-				Expires = DateTime.Now.AddDays(7),
-				SigningCredentials = creds
+				Expires = DateTime.UtcNow.AddDays(7),
+				SigningCredentials = creds,
+				Issuer = issuer,
+				Audience = audience
 			};
 
 			var tokenHandler = new JwtSecurityTokenHandler();

--- a/src/SharedData/Models/ChatSession.cs
+++ b/src/SharedData/Models/ChatSession.cs
@@ -5,7 +5,7 @@
 		public Guid Id { get; set; } = Guid.NewGuid();
 		// Links to exisiting user table
 		public Guid UserId { get; set; }
-		public string Title { get; set; } = "New Analysis";
+		public string? Title { get; set; } = "New Analysis";
 		public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
 		public List<ChatMessageRecord> Messages { get; set; } = new();


### PR DESCRIPTION
Refactored the AI financial streaming service to decouple explicit user identity dependencies from the request payload. The service is now completely stateless, relying strictly on cryptographically signed JWT bearer tokens passed through the API gateway context to enforce data isolation boundaries.

- Stateless API Shift: Completely removed the UserId string argument from the inbound request body models.
- Context Extraction: Injected IHttpContextAccessor into FinanceAgentService and implemented a helper utility (GetUserIdFromClaims) to parse out ClaimTypes.NameIdentifier dynamically.
- Semantic Kernel Alignment: Leveraged the active kernel memory tracking layer (_kernel.Data["userId"]) to hand off the runtime identity context seamlessly to downstream semantic plugins without crashing the event loop.
- Schema Resilience: Patched properties within the ChatSession data model to be nullable reference types (string?) to handle sparse legacy database entries safely.

**Verification & Testing**

- [x] Verified via Postman that requests with valid bearer tokens invoke financial data tool plugins successfully and return streaming AI content.
- [x] Verified that unauthenticated requests throw appropriate identity parsing contexts before invoking LLM pipelines.
